### PR TITLE
fix(959): keep search input when leave the app

### DIFF
--- a/ui-search/src/main/java/com/michaldrabik/ui_search/SearchFragment.kt
+++ b/ui-search/src/main/java/com/michaldrabik/ui_search/SearchFragment.kt
@@ -126,7 +126,6 @@ class SearchFragment :
     viewModel.clearSuggestions()
     with(binding) {
       searchViewLayout.binding.searchViewInput.removeTextChangedListener(this@SearchFragment)
-      searchViewLayout.binding.searchViewInput.setText("")
     }
     super.onStop()
   }


### PR DESCRIPTION
Related issue: https://github.com/michaldrabik/Showly/issues/959

Keeping the user inputed text in the search bar when the user leaves the app.



 
